### PR TITLE
modules/openstack/secgroups/*: Allow ingress traffic within cluster

### DIFF
--- a/modules/openstack/secgroups/rules/k8s/secgroup.tf
+++ b/modules/openstack/secgroups/rules/k8s/secgroup.tf
@@ -8,11 +8,11 @@ resource "openstack_networking_secgroup_rule_v2" "https" {
   security_group_id = "${var.secgroup_id}"
 }
 
-resource "openstack_networking_secgroup_rule_v2" "cAdvisor" {
+resource "openstack_networking_secgroup_rule_v2" "cluster" {
   direction         = "ingress"
   ethertype         = "IPv4"
-  port_range_min    = 4194
-  port_range_max    = 4194
+  port_range_min    = 1
+  port_range_max    = 65535
   protocol          = "tcp"
   remote_ip_prefix  = "${var.cluster_cidr}"
   security_group_id = "${var.secgroup_id}"


### PR DESCRIPTION
Relax the security group rules to allow ingress on all ports on the
internal subnet used by the k8s cluster. This subnet is not exposed
to the internet, and network policy can be applied directly to the k8s
cluster via NetworkPolicy objects, so the security posture remains
essentially unchanged.