### PR TITLE
K8S-795: Fix installer kubelet env path.

### DIFF
--- a/modules/ignition/assets.tf
+++ b/modules/ignition/assets.tf
@@ -156,7 +156,7 @@ data "template_file" "installer_kubelet_env" {
 
 data "ignition_file" "installer_kubelet_env" {
   filesystem = "root"
-  path       = "/etc/kubernetes/installer/kubelet.env"
+  path       = "/etc/kubernetes/kubelet.env"
   mode       = 0644
 
   content {


### PR DESCRIPTION
This address the problem that I have been encountering with scaling a cluster for which I have set a custom hyperkube; it's still not entirely clear to me what `/etc/kubernetes/installer/kubelet.env` is useful for but without this change there are cases where that value becomes out of sync with `/etc/kubernetes/kubelet.env`.