### PR TITLE
Update to hyperkube 1.9.6 w/ cinder detach patch.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -80,7 +80,7 @@ variable "tectonic_container_images" {
     flannel                      = "quay.io/coreos/flannel:v0.8.0-amd64"
     flannel_cni                  = "quay.io/coreos/flannel-cni:v0.2.0"
     heapster                     = "gcr.io/google_containers/heapster:v1.4.1"
-    hyperkube                    = "quay.io/coreos/hyperkube:v1.9.3_coreos.0"
+    hyperkube                    = "quay.io/rackspace/hyperkube:v1.9.6_rackspace.0"
     identity                     = "quay.io/coreos/dex:v2.8.1"
     ingress_controller           = "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.17"
     kenc                         = "quay.io/coreos/kenc:0.0.2"


### PR DESCRIPTION
This hyperkube is here:
https://quay.io/repository/rackspace/hyperkube?tab=tags