### PR TITLE
K8S-847: Fix etcd client auth

### DIFF
--- a/modules/ignition/etcd.tf
+++ b/modules/ignition/etcd.tf
@@ -13,11 +13,13 @@ EOF
 
   cert_options = <<EOF
 --cert-file=/etc/ssl/etcd/server.crt \
+  --client-cert-auth=true \
   --key-file=/etc/ssl/etcd/server.key \
   --peer-cert-file=/etc/ssl/etcd/peer.crt \
+  --peer-client-cert-auth=true \
   --peer-key-file=/etc/ssl/etcd/peer.key \
   --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
-  --peer-client-cert-auth=trueEOF
+  --trusted-ca-file=/etc/ssl/etcd/ca.crtEOF
 }
 
 data "template_file" "etcd_names" {


### PR DESCRIPTION
etcd was incorrectly configured to skip client authentication. Add
the revelant flags to the etcd services to enable this auth.