### PR TITLE
K8S-407: Allow additional public keys to be added to authorized_keys on core account

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -608,3 +608,12 @@ Global proxy settings will not be affected in this case.
 When set to false, the proxy settings will apply globally, including to all processes lauched by users.
 EOF
 }
+
+variable "rackspace_authorized_public_keys" {
+  type    = "list"
+  default = []
+
+  description = <<EOF
+(optional) Public keys of keypairs authorized to SSH into cluster nodes.
+EOF
+}

--- a/modules/openstack/etcd/ignition.tf
+++ b/modules/openstack/etcd/ignition.tf
@@ -8,7 +8,7 @@ data "ignition_config" "etcd" {
   files = ["${compact(list(
     data.ignition_file.resolv_conf.id,
     var.ign_profile_env_id,
-    var.ign_systemd_default_env_id,
+    var.ign_systemd_default_env_id
    ))}",
     "${var.ign_etcd_crt_id_list}",
     "${var.ign_ntp_dropin_id}",
@@ -56,6 +56,10 @@ EOF
 }
 
 data "ignition_user" "core" {
-  name                = "core"
-  ssh_authorized_keys = ["${var.core_public_keys}"]
+  name = "core"
+
+  ssh_authorized_keys = ["${compact(concat(
+    var.core_public_keys,
+    var.rackspace_authorized_public_keys
+  ))}"]
 }

--- a/modules/openstack/etcd/variables.tf
+++ b/modules/openstack/etcd/variables.tf
@@ -61,3 +61,8 @@ variable "ign_systemd_default_env_id" {
 variable "ign_ntp_dropin_id" {
   type = "string"
 }
+
+variable "rackspace_authorized_public_keys" {
+  type        = "list"
+  description = "Public keys of keypairs authorized to SSH into cluster nodes."
+}

--- a/modules/openstack/nodes/ignition.tf
+++ b/modules/openstack/nodes/ignition.tf
@@ -19,7 +19,7 @@ data "ignition_config" "node" {
     var.ign_nfs_config_id,
     var.ign_ntp_dropin_id,
     var.ign_profile_env_id,
-    var.ign_systemd_default_env_id,
+    var.ign_systemd_default_env_id
    ))}",
     "${var.ign_ca_cert_id_list}",
   ]
@@ -34,7 +34,7 @@ data "ignition_config" "node" {
     var.ign_bootkube_path_unit_id,
     var.ign_tectonic_path_unit_id,
     var.ign_update_ca_certificates_dropin_id,
-    var.ign_iscsi_service_id,
+    var.ign_iscsi_service_id
    ))}"]
 }
 
@@ -50,8 +50,12 @@ data "ignition_file" "resolv_conf" {
 }
 
 data "ignition_user" "core" {
-  name                = "core"
-  ssh_authorized_keys = ["${var.core_public_keys}"]
+  name = "core"
+
+  ssh_authorized_keys = ["${compact(concat(
+    var.core_public_keys,
+    var.rackspace_authorized_public_keys
+  ))}"]
 }
 
 data "ignition_file" "hostname" {

--- a/modules/openstack/nodes/variables.tf
+++ b/modules/openstack/nodes/variables.tf
@@ -84,3 +84,8 @@ variable "cloud_ca_pem_data" {
 variable "authentication_token_webhook_url" {
   type = "string"
 }
+
+variable "rackspace_authorized_public_keys" {
+  type        = "list"
+  description = "Public keys of keypairs authorized to SSH into cluster nodes."
+}

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -155,20 +155,21 @@ search ${var.tectonic_base_domain}
 ${join("\n", formatlist("nameserver %s", var.tectonic_openstack_dns_nameservers))}
 EOF
 
-  base_domain                   = "${var.tectonic_base_domain}"
-  cluster_name                  = "${var.tectonic_cluster_name}"
-  container_image               = "${var.tectonic_container_images["etcd"]}"
-  core_public_keys              = ["${module.secrets.core_public_key_openssh}"]
-  ign_coreos_metadata_dropin_id = "${module.ignition_masters.coreos_metadata_dropin_id}"
-  ign_etcd_crt_id_list          = "${module.ignition_masters.etcd_crt_id_list}"
-  ign_etcd_dropin_id_list       = "${module.ignition_masters.etcd_dropin_id_list}"
-  ign_node_exporter_service_id   = "${module.ignition_masters.node_exporter_service_id}"
-  ign_profile_env_id            = "${module.ignition_masters.profile_env_id}"
-  ign_systemd_default_env_id    = "${module.ignition_masters.systemd_default_env_id}"
-  ign_ntp_dropin_id             = "${length(var.tectonic_ntp_servers) > 0 ? module.ignition_masters.ntp_dropin_id : ""}"
-  instance_count                = "${var.tectonic_etcd_count}"
-  self_hosted_etcd              = "${var.tectonic_self_hosted_etcd}"
-  tls_enabled                   = "${var.tectonic_etcd_tls_enabled}"
+  base_domain                      = "${var.tectonic_base_domain}"
+  cluster_name                     = "${var.tectonic_cluster_name}"
+  container_image                  = "${var.tectonic_container_images["etcd"]}"
+  core_public_keys                 = ["${module.secrets.core_public_key_openssh}"]
+  ign_coreos_metadata_dropin_id    = "${module.ignition_masters.coreos_metadata_dropin_id}"
+  ign_etcd_crt_id_list             = "${module.ignition_masters.etcd_crt_id_list}"
+  ign_etcd_dropin_id_list          = "${module.ignition_masters.etcd_dropin_id_list}"
+  ign_node_exporter_service_id     = "${module.ignition_masters.node_exporter_service_id}"
+  ign_profile_env_id               = "${module.ignition_masters.profile_env_id}"
+  ign_systemd_default_env_id       = "${module.ignition_masters.systemd_default_env_id}"
+  ign_ntp_dropin_id                = "${length(var.tectonic_ntp_servers) > 0 ? module.ignition_masters.ntp_dropin_id : ""}"
+  instance_count                   = "${var.tectonic_etcd_count}"
+  rackspace_authorized_public_keys = "${var.rackspace_authorized_public_keys}"
+  self_hosted_etcd                 = "${var.tectonic_self_hosted_etcd}"
+  tls_enabled                      = "${var.tectonic_etcd_tls_enabled}"
 }
 
 module "ignition_masters" {
@@ -252,6 +253,7 @@ EOF
   cloud_ca_pem_data                    = "${file(var.tectonic_openstack_ca_pem_file != "" ? pathexpand(var.tectonic_openstack_ca_pem_file) : "/dev/null")}"
   floating_ip_network_id               = "${var.tectonic_openstack_external_network_id}"
   authentication_token_webhook_url     = "${var.authentication_token_webhook_url}"
+  rackspace_authorized_public_keys     = "${var.rackspace_authorized_public_keys}"
 }
 
 module "ignition_workers" {
@@ -318,6 +320,7 @@ EOF
   cloud_ca_pem_data                    = "${file(var.tectonic_openstack_ca_pem_file != "" ? pathexpand(var.tectonic_openstack_ca_pem_file) : "/dev/null")}"
   floating_ip_network_id               = "${var.tectonic_openstack_external_network_id}"
   authentication_token_webhook_url     = "${var.authentication_token_webhook_url}"
+  rackspace_authorized_public_keys     = "${var.rackspace_authorized_public_keys}"
 }
 
 module "secrets" {


### PR DESCRIPTION
Rackspace support needs the ability to SSH into instances for troubleshooting,
so add the ability to add additional keys to the list of authorized_keys on the
core (root) account.

```bash
$ ssh -i support_key_rsa core@172.99.78.23
Warning: Permanently added '172.99.78.23' (ECDSA) to the list of known hosts.
Container Linux by CoreOS stable (1632.3.0)
Update Strategy: No Reboots
core@levi7625-terraform-master-0 ~ $

$ ssh -i clusters/levi7625-terraform/id_rsa_core core@172.99.78.23
Warning: Permanently added '172.99.78.23' (ECDSA) to the list of known hosts.
Container Linux by CoreOS stable (1632.3.0)
Update Strategy: No Reboots
core@levi7625-terraform-master-0 ~ $
```